### PR TITLE
[gcc] : Fix C++11 support for gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(matrix-viewer)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 # sources
 set(PROJECT_SOURCES
   src/main.cc


### PR DESCRIPTION
gcc doesn't work without recent c++ standard (because of nullptr(s))